### PR TITLE
Fix "keys changed during iteration" error

### DIFF
--- a/apps/jsonapp.py
+++ b/apps/jsonapp.py
@@ -99,7 +99,7 @@ class JSONApp(WorkflowApp):  # pylint: disable=too-few-public-methods
 
         # input metadata arrange by role
         for role, input_id in input_ids.items():
-            for key in input_metadata.keys():
+            for key in list(input_metadata.keys()):
                 if key == input_id:
                     input_metadata[role] = input_metadata.pop(key)
 


### PR DESCRIPTION
This change is necessary for compatibility with Python 3.8, where iterating over a changing dictionary raises and error as opposed the warning produced by previous versions. The solution is just to iterate over a list with the keys of the dictionary instead of a view object. For further info see https://cito.github.io/blog/never-iterate-a-changing-dict/